### PR TITLE
Fix hardcoded data paths

### DIFF
--- a/src/combine_datasets.py
+++ b/src/combine_datasets.py
@@ -3,8 +3,13 @@ import glob
 import os
 
 
-INPUT_DIR = r"C:\Users\dayrb\Desktop\DGA_Project\data\original"
-OUTPUT_FILE = r"C:\Users\dayrb\Desktop\DGA_Project\data\master_dataset.csv"
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+# Folder containing the raw CSV files shipped with the repository
+INPUT_DIR = os.path.join(BASE_DIR, "original")
+
+# Destination for the combined dataset
+OUTPUT_FILE = os.path.join(BASE_DIR, "master_dataset.csv")
 
 def main():
     csv_files = glob.glob(os.path.join(INPUT_DIR, "*.csv"))

--- a/src/generate_dirty_reports.py
+++ b/src/generate_dirty_reports.py
@@ -2,9 +2,13 @@ import pandas as pd
 import random
 import os
 
-MASTER_CSV = r"C:\Users\dayrb\Desktop\DGA_Project\data\master_dataset.csv"
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-DIRTY_CSV  = r"C:\Users\dayrb\Desktop\DGA_Project\data\dirty_reports.csv"
+# Input dataset used to generate textual reports
+MASTER_CSV = os.path.join(BASE_DIR, "master_dataset.csv")
+
+# Output file with generated noisy textual reports
+DIRTY_CSV = os.path.join(BASE_DIR, "dirty_reports.csv")
 
 N_SAMPLES = 200
 

--- a/src/parse_dirty_reports.py
+++ b/src/parse_dirty_reports.py
@@ -5,9 +5,13 @@ import spacy
 from spacy.pipeline import EntityRuler
 
 
-DIRTY_CSV = r"C:\Users\dayrb\Desktop\DGA_Project\data\dirty_reports.csv"
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-PARSED_CSV = r"C:\Users\dayrb\Desktop\DGA_Project\data\parsed_table.csv"
+# Location of the generated textual reports
+DIRTY_CSV = os.path.join(BASE_DIR, "dirty_reports.csv")
+
+# File that will store the parsed numerical values
+PARSED_CSV = os.path.join(BASE_DIR, "parsed_table.csv")
 
 GAS_NAMES = {
     "Hydrogen": ["H2", "H₂", "Hydrogen", "Водород"],


### PR DESCRIPTION
## Summary
- make dataset scripts use repository-relative paths

## Testing
- `python -m py_compile src/*.py`
- `python src/parse_dirty_reports.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6845d8f6d1a08332a5ccc9a00d632df7